### PR TITLE
Allow specifying hyphen character.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -38,6 +38,11 @@ interpreters.
   points = hh.hyphenate(word)  #=> [3, 5, 8, 10]
   puts hh.visualize(word)      #=> rep-re-sen-ta-tion
 
+Both visualize and hyphenate_to methods allow choosing a custom hyphen:
+
+  puts hh.visualize(word, "&shy;") #=> rep&shy;re&shy;sen&shy;ta&shy;tion
+
+
 Text::Hyphen is truly multilingual, with 29 languages or language variants
 supported. As an example, consider the difference between the following:
 

--- a/lib/text/hyphen.rb
+++ b/lib/text/hyphen.rb
@@ -150,6 +150,10 @@ class Text::Hyphen
   #
   #   hyp.visualize('representation') #=> rep-re-sen-ta-tion
   #
+  # Any string can be set instead of the default hyphen:
+  #
+  #   hyp.visualize('example', '&shy;') #=> exam&shy;ple
+  #
   # Because hyphenation can be expensive, if the word has been visualised
   # previously, it will be returned from a per-instance cache.
   def visualise(word, hyphen = '-')
@@ -169,6 +173,10 @@ class Text::Hyphen
   end
 
   # This function will hyphenate a word so that the first point is at most
+  #
+  # NOTE: if hyphen is set to a string, it will still be counted as one
+  # character (since it represents a hyphen)
+  #
   # +size+ characters.
   def hyphenate_to(word, size, hyphen = '-')
     point = hyphenate(word).delete_if { |e| e >= size }.max

--- a/test/test_text_hyphen.rb
+++ b/test/test_text_hyphen.rb
@@ -27,7 +27,7 @@ class TestTextHyphen < Test::Unit::TestCase
               %w(play- back), [nil, 'presents'], %w(pro- grammable),
               %w(rep- resentation)]
 
-  SOFT_HYPHEN = "1.9".respond_to?(:encoding) ? "\u00AD" : "\302\255"
+  SOFT_HYPHEN = "&shy;"
 
   def test_hyphenate
     @r = []


### PR DESCRIPTION
Hi!

Patch (with tests) that allows user to specify something other than '-' (hyphen-minus) for hyphen.

Tested on Ruby 1.9.3  and 1.8.7.

I was wondering if this belongs here. I believe it does, since prawnpdf/prawn expects the soft-hyphen "\u00AD" instead.

Sure, users could just use:

```
.gsub('-', "\u00AD")
```

but that would need to be done on every word, even when the result is already cached by text-hyphen.

Also, people often use the minus sign because it's on the keyboard, when they really mean one of:
- hyphen bullet ("\u2043") [yes, I just "sinned" too, but markdown forgives me ...]
- non-breaking hyphen ("\u2011")
- unicode minus sign ("\2212")
- a ... um ... hyphen ("\2010")

Sorry for the rant, I just wanted to show I did my homework and some thinking.
