### PR TITLE
Fix error when calling #aliases_for in NO1 and NO2

### DIFF
--- a/lib/text/hyphen/language/no1.rb
+++ b/lib/text/hyphen/language/no1.rb
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 
 Text::Hyphen.require_real_hyphenation_file(__FILE__)
-Text::Hyphen::Language.aliases_for "NO1" => "NO NOR"
+Text::Hyphen::Language.aliases_for "NO1" => %W(NO NOR)

--- a/lib/text/hyphen/language/no2.rb
+++ b/lib/text/hyphen/language/no2.rb
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 
 Text::Hyphen.require_real_hyphenation_file(__FILE__)
-Text::Hyphen::Language.aliases_for "NO2" => "NO NOR"
+Text::Hyphen::Language.aliases_for "NO2" => %W(NO NOR)


### PR DESCRIPTION
passing string when it should be array
