### PR TITLE
Add sentence support

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,9 @@
+== 1.5.0 / 2022.11.23
+
+* Feature
+  * Anes Hodza (https://github.com/aneshodza) added support for full
+    sentences when hyphenating.
+
 == 1.4.1 / 2012.08.27
 
 * Bug Fix:

--- a/README.rdoc
+++ b/README.rdoc
@@ -35,6 +35,11 @@ Ruby 1.8. New features will be developed and tested against Ruby 1.9 only.
   points = hh.hyphenate(word)  #=> [3, 5, 8, 10]
   puts hh.visualize(word)      #=> rep-re-sen-ta-tion
 
+  # Sentences are also supported
+  sentece = "This is a sentence."
+  points = hh.hyphenate(sentece)  #=> [13]
+  puts hh.visualize(sentece)      #=> This is a sen-tence.
+
 Both visualize and hyphenate_to methods allow choosing a custom hyphen:
 
   puts hh.visualize(word, "&shy;") #=> rep&shy;re&shy;sen&shy;ta&shy;tion

--- a/README.rdoc
+++ b/README.rdoc
@@ -36,7 +36,7 @@ Ruby 1.8. New features will be developed and tested against Ruby 1.9 only.
   puts hh.visualize(word)      #=> rep-re-sen-ta-tion
 
   # Sentences are also supported
-  sentece = "This is a sentence."
+  sentece = "This useful library supports sentences."
   points = hh.hyphenate(sentece)  #=> [8, 14, 23, 27, 32]
   puts hh.visualize(sentece)      #=> This use-ful li-brary sup-port-s sen-tences.
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -37,8 +37,8 @@ Ruby 1.8. New features will be developed and tested against Ruby 1.9 only.
 
   # Sentences are also supported
   sentece = "This is a sentence."
-  points = hh.hyphenate(sentece)  #=> [13]
-  puts hh.visualize(sentece)      #=> This is a sen-tence.
+  points = hh.hyphenate(sentece)  #=> [8, 14, 23, 27, 32]
+  puts hh.visualize(sentece)      #=> This use-ful li-brary sup-port-s sen-tences.
 
 Both visualize and hyphenate_to methods allow choosing a custom hyphen:
 

--- a/bin/ruby-hyphen
+++ b/bin/ruby-hyphen
@@ -87,20 +87,9 @@ when :visualise
 when :hyphenate
   ARGV.each do |word|
     hyp = hyphenator.hyphenate(word)
-    if hyp.kind_of?(Array)
-      split_word = word.split(/[[:blank:]]/)
-      hyp.each_with_index do |single_hyp, i|
-        unless single_hyp.empty?
-          print "#{split_word[i]}: "
-          single_hyp.each { |pt| print "#{split_word[i][pt, 1]} "}
-          puts
-        end
-      end
-    else
-      print "#{word}: "
-      hyp.each { |pt| print "#{word[pt, 1]} " }
-      puts
-    end
+    print "#{word}: "
+    hyp.each { |pt| print "#{word[pt, 1]} " }
+    puts
   end
 when :hyphenate_to
   size = 80

--- a/bin/ruby-hyphen
+++ b/bin/ruby-hyphen
@@ -87,9 +87,20 @@ when :visualise
 when :hyphenate
   ARGV.each do |word|
     hyp = hyphenator.hyphenate(word)
-    print "#{word}: "
-    hyp.each { |pt| print "#{word[pt, 1]} " }
-    puts
+    if hyp.kind_of?(Array)
+      split_word = word.split(/[[:blank:]]/)
+      hyp.each_with_index do |single_hyp, i|
+        unless single_hyp.empty?
+          print "#{split_word[i]}: "
+          single_hyp.each { |pt| print "#{split_word[i][pt, 1]} "}
+          puts
+        end
+      end
+    else
+      print "#{word}: "
+      hyp.each { |pt| print "#{word[pt, 1]} " }
+      puts
+    end
   end
 when :hyphenate_to
   size = 80

--- a/test/test_text_hyphen.rb
+++ b/test/test_text_hyphen.rb
@@ -30,6 +30,9 @@ class TestTextHyphen < Test::Unit::TestCase
 
   SOFT_HYPHEN = "&shy;"
 
+  VISUAL_SENTENCE = "This use-ful li-brary sup-port-s sen-tences."
+  POINTS_SENTENCE = [[], [3], [2], [3, 7], [3]]
+
   def test_hyphenate
     @r = []
     a = Text::Hyphen.new do |xx|
@@ -74,5 +77,15 @@ class TestTextHyphen < Test::Unit::TestCase
   def test_russian
     a = Text::Hyphen.new(:language => 'ru').visualize('скоропалительный')
     assert_equal "ско-ро-па-ли-тель-ный", a
+  end
+
+  def test_hyphenate_sentence
+    a = Text::Hyphen.new(:left => 0, :right => 0).hyphenate('This useful library supports sentences.')
+    assert_equal POINTS_SENTENCE, a
+  end
+
+  def test_visualise_sentence
+    a = Text::Hyphen.new(:left => 0, :right => 0).visualize('This useful library supports sentences.')
+    assert_equal VISUAL_SENTENCE, a
   end
 end

--- a/test/test_text_hyphen.rb
+++ b/test/test_text_hyphen.rb
@@ -31,7 +31,7 @@ class TestTextHyphen < Test::Unit::TestCase
   SOFT_HYPHEN = "&shy;"
 
   VISUAL_SENTENCE = "This use-ful li-brary sup-port-s sen-tences."
-  POINTS_SENTENCE = [[], [3], [2], [3, 7], [3]]
+  POINTS_SENTENCE = [8, 14, 23, 27, 32]
 
   def test_hyphenate
     @r = []

--- a/text-hyphen.gemspec
+++ b/text-hyphen.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: text-hyphen 1.4.1 ruby lib
+# stub: text-hyphen 1.5.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "text-hyphen".freeze
-  s.version = "1.4.1"
+  s.version = "1.5.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
-  s.date = "2022-09-29"
+  s.date = "2022-11-23"
   s.description = "Text::Hyphen is a Ruby library to hyphenate words in various languages using\nRuby-fied versions of TeX hyphenation patterns. It will properly hyphenate\nvarious words according to the rules of the language the word is written in.\nThe algorithm is based on that of the TeX typesetting system by Donald E.\nKnuth.\n\nThis is originally based on the Perl implementation of\n{TeX::Hyphen}[http://search.cpan.org/author/JANPAZ/TeX-Hyphen-0.140/lib/TeX/Hyphen.pm]\nand the {Ruby port}[http://rubyforge.org/projects/text-format]. The language\nhyphenation pattern files are based on the sources available from\n{CTAN}[http://www.ctan.org] as of 2004.12.19 and have been manually translated\nby Austin Ziegler.\n\nThis is a small feature release adding Russian language support and fixing a\nbug in the custom hyphen support introduced last version. This release provides\nboth Ruby 1.8.7 and Ruby 1.9.2 support (but please read below). In short, Ruby\n1.8 support is deprecated and I will not be providing any bug fixes related to\nRuby 1.8. New features will be developed and tested against Ruby 1.9 only.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.executables = ["ruby-hyphen".freeze]
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://rubygems.org/gems/text-hyphen".freeze
   s.licenses = ["MIT".freeze, "Various".freeze]
   s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
-  s.rubygems_version = "3.3.7".freeze
+  s.rubygems_version = "3.3.24".freeze
   s.summary = "Text::Hyphen is a Ruby library to hyphenate words in various languages using Ruby-fied versions of TeX hyphenation patterns".freeze
 
   if s.respond_to? :specification_version then
@@ -30,13 +30,13 @@ Gem::Specification.new do |s|
     s.add_development_dependency(%q<hoe-git>.freeze, ["~> 1.6"])
     s.add_development_dependency(%q<hoe-seattlerb>.freeze, ["~> 1.0"])
     s.add_development_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
-    s.add_development_dependency(%q<hoe>.freeze, ["~> 3.25"])
+    s.add_development_dependency(%q<hoe>.freeze, ["~> 3.26"])
   else
     s.add_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
     s.add_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
     s.add_dependency(%q<hoe-git>.freeze, ["~> 1.6"])
     s.add_dependency(%q<hoe-seattlerb>.freeze, ["~> 1.0"])
     s.add_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
-    s.add_dependency(%q<hoe>.freeze, ["~> 3.25"])
+    s.add_dependency(%q<hoe>.freeze, ["~> 3.26"])
   end
 end

--- a/text-hyphen.gemspec
+++ b/text-hyphen.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
-  s.date = "2022-11-23"
+  s.date = "2022-11-25"
   s.description = "Text::Hyphen is a Ruby library to hyphenate words in various languages using\nRuby-fied versions of TeX hyphenation patterns. It will properly hyphenate\nvarious words according to the rules of the language the word is written in.\nThe algorithm is based on that of the TeX typesetting system by Donald E.\nKnuth.\n\nThis is originally based on the Perl implementation of\n{TeX::Hyphen}[http://search.cpan.org/author/JANPAZ/TeX-Hyphen-0.140/lib/TeX/Hyphen.pm]\nand the {Ruby port}[http://rubyforge.org/projects/text-format]. The language\nhyphenation pattern files are based on the sources available from\n{CTAN}[http://www.ctan.org] as of 2004.12.19 and have been manually translated\nby Austin Ziegler.\n\nThis is a small feature release adding Russian language support and fixing a\nbug in the custom hyphen support introduced last version. This release provides\nboth Ruby 1.8.7 and Ruby 1.9.2 support (but please read below). In short, Ruby\n1.8 support is deprecated and I will not be providing any bug fixes related to\nRuby 1.8. New features will be developed and tested against Ruby 1.9 only.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.executables = ["ruby-hyphen".freeze]


### PR DESCRIPTION
I added sentence support to the library by checking if the input is divisible by `[[:empty:]]`. If thats the case we return the result of the same function called on every word. If more tests are needed, I can also write some more.
Because of the "big" changes that were done I decided that I may be the best choice if this bumps the libraries version to 1.5.0